### PR TITLE
Use records returned by ionos api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.envrc
 _gitignore/
 *~

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # IONOS DNS API for `libdns`
 
 This package implements the libdns interfaces for the [IONOS DNS
-API (beta)](https://developer.hosting.ionos.de/docs/dns)
+API](https://developer.hosting.ionos.de/docs/dns)
 
 ## Authenticating
 


### PR DESCRIPTION
 IONOS changed the API so that create response now returns the create records. That makes the call to read the previously created records obsolete.