### PR TITLE
Search records when id is not provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .envrc
 _gitignore/
 *~
+coverage.out

--- a/README.md
+++ b/README.md
@@ -60,20 +60,32 @@ tests:
 $ export LIBDNS_IONOS_TEST_ZONE=mydomain.org
 $ export LIBDNS_IONOS_TEST_TOKEN=aaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 $ go  test -v
+go test -v
 === RUN   Test_AppendRecords
---- PASS: Test_AppendRecords (43.01s)
+=== RUN   Test_AppendRecords/testcase_0
+=== RUN   Test_AppendRecords/testcase_1
+=== RUN   Test_AppendRecords/testcase_2
+--- PASS: Test_AppendRecords (6.71s)
+    --- PASS: Test_AppendRecords/testcase_0 (2.51s)
+    --- PASS: Test_AppendRecords/testcase_1 (2.15s)
+    --- PASS: Test_AppendRecords/testcase_2 (2.05s)
 === RUN   Test_DeleteRecords
---- PASS: Test_DeleteRecords (23.91s)
+=== RUN   Test_DeleteRecords/clear_record.ID=true
+=== RUN   Test_DeleteRecords/clear_record.ID=false
+--- PASS: Test_DeleteRecords (9.62s)
+    --- PASS: Test_DeleteRecords/clear_record.ID=true (4.81s)
+    --- PASS: Test_DeleteRecords/clear_record.ID=false (4.80s)
 === RUN   Test_GetRecords
---- PASS: Test_GetRecords (30.96s)
-=== RUN   Test_SetRecords
---- PASS: Test_SetRecords (51.39s)
+--- PASS: Test_GetRecords (4.41s)
+=== RUN   Test_UpdateRecords
+=== RUN   Test_UpdateRecords/clear_record.ID=true
+=== RUN   Test_UpdateRecords/clear_record.ID=false
+--- PASS: Test_UpdateRecords (10.14s)
+    --- PASS: Test_UpdateRecords/clear_record.ID=true (5.84s)
+    --- PASS: Test_UpdateRecords/clear_record.ID=false (4.30s)
 PASS
-ok  	github.com/libdns/ionos	149.277s
+ok  	github.com/libdns/ionos	30.884s
 ```
-
-The tests were taken from the [Hetzner libdns
-module](https://github.com/libdns/hetzner) and are not modified.
 
 ## Author
 

--- a/_example/example.go
+++ b/_example/example.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/libdns/ionos"
+)
+
+func main() {
+	token := os.Getenv("LIBDNS_IONOS_TOKEN")
+	if token == "" {
+		panic("LIBDNS_IONOS_TOKEN not set")
+	}
+
+	zone := os.Getenv("LIBDNS_IONOS_ZONE")
+	if zone == "" {
+		panic("LIBDNS_IONOS_ZONE not set")
+	}
+
+	p := &ionos.Provider{
+		AuthAPIToken: token,
+	}
+
+	records, err := p.GetRecords(context.TODO(), zone)
+	if err != nil {
+		panic(err)
+	}
+
+	out, _ := json.MarshalIndent(records, "", "  ")
+	fmt.Println(string(out))
+}

--- a/client.go
+++ b/client.go
@@ -130,19 +130,18 @@ func ionosGetZone(ctx context.Context, token string, zoneID string, recordType, 
 	return result, err
 }
 
-// ionosFindRecordInZone is a convenience function to search all records in the
+// ionosFindRecordsInZone is a convenience function to search all records in the
 // given zone for a record with the given name and type and returns this record
 // on success
-func ionosFindRecordInZone(ctx context.Context, token string, zoneID, typ, name string) (zoneRecord, error) {
+func ionosFindRecordsInZone(ctx context.Context, token string, zoneID, typ, name string) ([]zoneRecord, error) {
 	resp, err := ionosGetZone(ctx, token, zoneID, typ, name)
 	if err != nil {
-		return zoneRecord{}, err
+		return nil, err
 	}
 	if len(resp.Records) < 1 {
-		return zoneRecord{}, fmt.Errorf("record not found in zone")
+		return nil, fmt.Errorf("record not found in zone")
 	}
-	// TODO what if > 1?
-	return resp.Records[0], nil
+	return resp.Records, nil
 }
 
 // ionosDeleteRecord deletes the given record

--- a/client.go
+++ b/client.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	APIEndpoint = "https://api.hosting.ionos.com/dns/v1"
-	maxRetries  = 3
 )
 
 type getAllZonesResponse struct {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/libdns/ionos
 
-go 1.16
+go 1.18
 
-require github.com/libdns/libdns v0.2.1
+require github.com/libdns/libdns v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.1 h1:Wu59T7wSHRgtA0cfxC+n1c/e+O3upJGWytknkmFEDis=
-github.com/libdns/libdns v0.2.1/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/provider.go
+++ b/provider.go
@@ -1,17 +1,13 @@
 // libdns implementation for IONOS DNS API.
-// libdns uses FQDN, i.e. domain names that terminate with ".". From the
-// libdns documentation:
-//   For example, an A record called "sub" in zone "example.com." represents
-//   a fully-qualified domain name (FQDN) of "sub.example.com."
-//
-// The IONOS API seems not to use FQDNs.
-//
-// https://developer.hosting.ionos.de/docs/dns
+// IONOS API documentaion: https://developer.hosting.ionos.de/docs/dns
+// libdns: https://github.com/libdns/libdns
 package ionos
 
 import (
 	"context"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/libdns/libdns"
 )
@@ -23,50 +19,185 @@ type Provider struct {
 	AuthAPIToken string `json:"auth_api_token"`
 }
 
+func toIonosRecord(r libdns.Record, zoneName string) record {
+	return record{
+		Type:    r.Type,
+		Name:    libdns.AbsoluteName(r.Name, zoneName),
+		Content: r.Value,
+		TTL:     ionosTTL(r.TTL.Seconds()),
+	}
+}
+
+func fromIonosRecord(r zoneRecord, zoneName string) libdns.Record {
+	return libdns.Record{
+		ID:   r.ID,
+		Type: r.Type,
+		// libdns Name is partially qualified, relative to zone, Ionos absoulte
+		Name:  libdns.RelativeName(r.Name, zoneName), // use r.rootName for zoneName TODO?
+		Value: r.Content,
+		TTL:   time.Duration(r.TTL) * time.Second,
+	}
+}
+
+func (p *Provider) findZoneByName(ctx context.Context, zoneName string) (zoneDescriptor, error) {
+	// obtain list of all zones
+	zones, err := ionosGetAllZones(ctx, p.AuthAPIToken)
+	if err != nil {
+		return zoneDescriptor{}, fmt.Errorf("get all zones: %w", err)
+	}
+
+	// find the desired zone
+	for _, zone := range zones.Zones {
+		if zone.Name == unFQDN(zoneName) {
+			return zone, nil
+		}
+	}
+	return zoneDescriptor{}, fmt.Errorf("zone named not found (%s)", zoneName)
+}
+
 // GetRecords lists all the records in the zone.
-func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record, error) {
-	return getAllRecords(ctx, p.AuthAPIToken, unFQDN(zone))
+func (p *Provider) GetRecords(ctx context.Context, zoneName string) ([]libdns.Record, error) {
+
+	zoneDes, err := p.findZoneByName(ctx, zoneName)
+	if err != nil {
+		return nil, fmt.Errorf("find zone: %w", err)
+	}
+
+	// obtain list of all records in zone
+	zoneResp, err := ionosGetZone(ctx, p.AuthAPIToken, zoneDes.ID, "", "")
+	if err != nil {
+		return nil, fmt.Errorf("get zone records: %w", err)
+	}
+
+	records := make([]libdns.Record, len(zoneResp.Records))
+	for i, r := range zoneResp.Records {
+		records[i] = fromIonosRecord(r, zoneName)
+	}
+	return records, nil
 }
 
 // AppendRecords adds records to the zone. It returns the records that were added.
-func (p *Provider) AppendRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	var appendedRecords []libdns.Record
+func (p *Provider) AppendRecords(
+	ctx context.Context,
+	zone string,
+	records []libdns.Record) ([]libdns.Record, error) {
 
-	for _, record := range records {
-		newRecord, err := createRecord(ctx, p.AuthAPIToken, unFQDN(zone), record)
-		if err != nil {
-			return nil, err
-		}
-		appendedRecords = append(appendedRecords, newRecord)
+	zoneDes, err := p.findZoneByName(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("find zone: %w", err)
 	}
-	return appendedRecords, nil
+
+	// populate ionos request
+	reqs := make([]record, len(records))
+	for i, r := range records {
+		reqs[i] = toIonosRecord(r, zoneDes.Name)
+	}
+
+	newRecords, err := ionosCreateRecords(ctx, p.AuthAPIToken, zoneDes.ID, reqs)
+	if err != nil {
+		return nil, fmt.Errorf("create records: %w", err)
+	}
+
+	// populate libdns response
+	res := make([]libdns.Record, len(records))
+	for i, r := range newRecords {
+		res[i] = fromIonosRecord(r, zoneDes.Name)
+	}
+	return res, nil
 }
 
-// DeleteRecords deletes the records from the zone.
-func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	for _, record := range records {
-		err := deleteRecord(ctx, p.AuthAPIToken, unFQDN(zone), record)
-		if err != nil {
-			return nil, err
-		}
+// DeleteRecords deletes the records from the zone. Returns the list of
+// records acutally deleted. Fails fast on first error, but in this case
+func (p *Provider) DeleteRecords(
+	ctx context.Context,
+	zone string,
+	records []libdns.Record) ([]libdns.Record, error) {
+
+	zoneDes, err := p.findZoneByName(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("find zone: %w", err)
 	}
-	return records, nil
+
+	// ionos api has no batch-delete, delete one record at a time
+	var res []libdns.Record
+	for _, r := range records {
+		id := r.ID
+		name := libdns.AbsoluteName(r.Name, zoneDes.Name)
+
+		// no ID provided, search record first
+		if id == "" {
+
+			existing, err := ionosFindRecordInZone(ctx, p.AuthAPIToken, zoneDes.ID, r.Type, name)
+			if err != nil {
+				return nil, fmt.Errorf("find record for deletion: %w", err)
+			}
+			id = existing.ID
+		}
+
+		err := ionosDeleteRecord(ctx, p.AuthAPIToken, zoneDes.ID, id)
+		if err != nil {
+			return nil, fmt.Errorf("delete record by ID: %w", err)
+		}
+		r.ID = id
+		res = append(res, r)
+	}
+	return res, nil
+}
+
+func (p *Provider) createOrUpdateRecord(
+	ctx context.Context,
+	zoneDes zoneDescriptor,
+	r libdns.Record) (libdns.Record, error) {
+
+	// an ID is provided, we can directly call the ionos api
+	if r.ID != "" {
+		err := ionosUpdateRecord(ctx, p.AuthAPIToken, zoneDes.ID, r.ID, toIonosRecord(r, zoneDes.Name))
+		if err != nil {
+			return r, fmt.Errorf("update record: %w", err)
+		}
+		return r, nil
+	}
+
+	// before we create a new record, make sure there is no existing record
+	// of same (type, name). In this case we only update the record
+	name := libdns.AbsoluteName(r.Name, zoneDes.Name)
+	existing, err := ionosFindRecordInZone(ctx, p.AuthAPIToken, zoneDes.ID, r.Type, name)
+	if err == nil {
+		err := ionosUpdateRecord(ctx, p.AuthAPIToken, zoneDes.ID, existing.ID, toIonosRecord(r, zoneDes.Name))
+		if err != nil {
+			return r, fmt.Errorf("update found record: %w", err)
+		}
+		r.ID = existing.ID
+		return r, nil
+	}
+	created, err := ionosCreateRecords(ctx, p.AuthAPIToken, zoneDes.ID, []record{toIonosRecord(r, zoneDes.Name)})
+	if err != nil {
+		return r, fmt.Errorf("create new record: %w", err)
+	}
+	if len(created) != 1 {
+		return r, fmt.Errorf("expected one record to be created, got %d", len(created))
+	}
+	return fromIonosRecord(created[0], zoneDes.Name), nil
 }
 
 // SetRecords sets the records in the zone, either by updating existing records
 // or creating new ones. It returns the updated records.
 func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
-	var setRecords []libdns.Record
+	var res []libdns.Record
 
-	for _, record := range records {
-		setRecord, err := createOrUpdateRecord(ctx, p.AuthAPIToken, unFQDN(zone), record)
-		if err != nil {
-			return setRecords, err
-		}
-		setRecords = append(setRecords, setRecord)
+	zoneDes, err := p.findZoneByName(ctx, zone)
+	if err != nil {
+		return nil, fmt.Errorf("find zone: %w", err)
 	}
 
-	return setRecords, nil
+	for _, r := range records {
+		newRecord, err := p.createOrUpdateRecord(ctx, zoneDes, r)
+		if err != nil {
+			return res, err
+		}
+		res = append(res, newRecord)
+	}
+	return res, nil
 }
 
 // unFQDN trims any trailing "." from fqdn. IONOS's API does not use FQDNs.

--- a/provider.go
+++ b/provider.go
@@ -6,6 +6,7 @@ package ionos
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,12 +30,19 @@ func toIonosRecord(r libdns.Record, zoneName string) record {
 }
 
 func fromIonosRecord(r zoneRecord, zoneName string) libdns.Record {
+	// IONOS returns TXT records quoted: remove quotes
+	var value string
+	if strings.ToUpper(r.Type) == "TXT" {
+		value, _ = strconv.Unquote(r.Content)
+	} else {
+		value = r.Content
+	}
 	return libdns.Record{
 		ID:   r.ID,
 		Type: r.Type,
 		// libdns Name is partially qualified, relative to zone, Ionos absoulte
 		Name:  libdns.RelativeName(r.Name, zoneName), // use r.rootName for zoneName TODO?
-		Value: r.Content,
+		Value: value,
 		TTL:   time.Duration(r.TTL) * time.Second,
 	}
 }

--- a/provider.go
+++ b/provider.go
@@ -131,16 +131,14 @@ func (p *Provider) DeleteRecords(
 
 	// collect IDs
 	for _, r := range records {
-		id := r.ID
-		name := libdns.AbsoluteName(r.Name, zoneDes.Name)
-
 		// no ID provided, search record first
-		if id == "" {
+		if r.ID == "" {
 			// safety: avoid to delete the whole zone
-			if r.Type == "" || name == "" {
+			if r.Type == "" || r.Name == "" {
 				continue
 			}
 
+			name := libdns.AbsoluteName(r.Name, zoneDes.Name)
 			existing, err := ionosFindRecordsInZone(ctx, p.AuthAPIToken, zoneDes.ID, r.Type, name)
 			if err != nil {
 				return nil, fmt.Errorf("find record for deletion: %w", err)

--- a/provider_test.go
+++ b/provider_test.go
@@ -109,8 +109,8 @@ func Test_AppendRecords(t *testing.T) {
 				{Type: "TXT", Name: prefix + "_test_2", Value: "val_2", TTL: 0},
 			},
 			expected: []libdns.Record{
-				{Type: "TXT", Name: prefix + "_test_1", Value: "\"val_1\"", TTL: ttl},
-				{Type: "TXT", Name: prefix + "_test_2", Value: "\"val_2\"", TTL: time.Hour},
+				{Type: "TXT", Name: prefix + "_test_1", Value: "val_1", TTL: ttl},
+				{Type: "TXT", Name: prefix + "_test_2", Value: "val_2", TTL: time.Hour},
 			},
 		},
 		{
@@ -119,7 +119,7 @@ func Test_AppendRecords(t *testing.T) {
 				{Type: "TXT", Name: prefix + "123.test", Value: "123", TTL: ttl},
 			},
 			expected: []libdns.Record{
-				{Type: "TXT", Name: prefix + "123.test", Value: "\"123\"", TTL: ttl},
+				{Type: "TXT", Name: prefix + "123.test", Value: "123", TTL: ttl},
 			},
 		},
 		{
@@ -185,7 +185,7 @@ func Test_DeleteRecords(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				checkExcatlyOneRecordExists(t, allRecords, "TXT", name, "\"my record\"")
+				checkExcatlyOneRecordExists(t, allRecords, "TXT", name, "my record")
 
 				// test with- and without a recordID
 				if clearID {

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,16 +1,18 @@
-//  end-to-end test suite, using the original IONOS API service (i.e. no test
-//  doubles - be careful).
-//	set environment variables
-//    LIBDNS_IONOS_TEST_TOKEN - API token
-//	  LIBDNS_IONOS_TEST_ZONE - domain
+// end-to-end test suite, using the original IONOS API service (i.e. no test
+// doubles - be careful). set environment variables
+//
+//	LIBDNS_IONOS_TEST_TOKEN - API token
+//	LIBDNS_IONOS_TEST_ZONE - domain
+//
 // before running the test.
-// (Tests taken from github.com/libdns/hetzner)
 package ionos_test
 
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -25,48 +27,261 @@ var (
 	ttl      = time.Duration(120 * time.Second)
 )
 
-type testRecordsCleanup = func()
+var letters = []rune("abcdefghijklmnopqrstuvwxyz")
 
-func setupTestRecords(t *testing.T, p *ionos.Provider) ([]libdns.Record, testRecordsCleanup) {
-	testRecords := []libdns.Record{
-		{
-			Type:  "TXT",
-			Name:  "test1",
-			Value: "test1",
-			TTL:   ttl,
-		}, {
-			Type:  "TXT",
-			Name:  "test2",
-			Value: "test2",
-			TTL:   ttl,
-		}, {
-			Type:  "TXT",
-			Name:  "test3",
-			Value: "test3",
-			TTL:   ttl,
-		}, {
-			Type:  "TXT",
-			Name:  "test4",
-			Value: "test4",
-			TTL:   0,
-		},
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
 	}
-
-	records, err := p.AppendRecords(context.TODO(), envZone, testRecords)
-	if err != nil {
-		t.Fatal(err)
-		return nil, func() {}
-	}
-
-	return records, func() {
-		cleanupRecords(t, p, records)
-	}
+	return string(b)
 }
 
 func cleanupRecords(t *testing.T, p *ionos.Provider, r []libdns.Record) {
+	t.Helper()
 	_, err := p.DeleteRecords(context.TODO(), envZone, r)
 	if err != nil {
 		t.Fatalf("cleanup failed: %v", err)
+	}
+}
+
+func checkExcatlyOneRecordExists(
+	t *testing.T,
+	records []libdns.Record,
+	recordType, name, value string) {
+
+	t.Helper()
+	name = strings.ToLower(name)
+	found := 0
+	for _, r := range records {
+		if r.Name == name {
+			found++
+			if r.Type != recordType || r.Value != value {
+				t.Fatalf("expected to find excatly one %s record with name %s and value of %s", recordType, name, value)
+			}
+		}
+	}
+	if found != 1 {
+		t.Fatalf("expected to find only one record named %s, but found %d", value, found)
+	}
+}
+
+func checkNoRecordExists(
+	t *testing.T,
+	records []libdns.Record,
+	name string) {
+
+	t.Helper()
+	for _, r := range records {
+		if r.Name == strings.ToLower(name) {
+			t.Fatalf("expected to find no record named %s", r.Name)
+		}
+	}
+}
+
+func containsRecord(probe libdns.Record, records []libdns.Record) *libdns.Record {
+	for _, r := range records {
+		if r.Name == probe.Name &&
+			r.Type == probe.Type &&
+			r.Value == probe.Value &&
+			r.TTL == probe.TTL {
+			return &r
+		}
+	}
+	return nil
+}
+
+// Test_AppendRecords creates various records using AppendRecords and checks
+// that the response returned is as expected. Records are not read back
+// using GetRecords, that's done in Test_GetRecords.
+func Test_AppendRecords(t *testing.T) {
+	p := &ionos.Provider{AuthAPIToken: envToken}
+
+	prefix := randSeq(32)
+	testCases := []struct {
+		records  []libdns.Record
+		expected []libdns.Record
+	}{
+		{
+			// multiple records
+			records: []libdns.Record{
+				{Type: "TXT", Name: prefix + "_test_1", Value: "val_1", TTL: ttl},
+				{Type: "TXT", Name: prefix + "_test_2", Value: "val_2", TTL: 0},
+			},
+			expected: []libdns.Record{
+				{Type: "TXT", Name: prefix + "_test_1", Value: "\"val_1\"", TTL: ttl},
+				{Type: "TXT", Name: prefix + "_test_2", Value: "\"val_2\"", TTL: time.Hour},
+			},
+		},
+		{
+			// relative name
+			records: []libdns.Record{
+				{Type: "TXT", Name: prefix + "123.test", Value: "123", TTL: ttl},
+			},
+			expected: []libdns.Record{
+				{Type: "TXT", Name: prefix + "123.test", Value: "\"123\"", TTL: ttl},
+			},
+		},
+		{
+			// A records
+			records: []libdns.Record{
+				{Type: "A", Name: prefix + "456.test.", Value: "1.2.3.4", TTL: ttl},
+			},
+			expected: []libdns.Record{
+				{Type: "A", Name: prefix + "456.test", Value: "1.2.3.4", TTL: ttl},
+			},
+		},
+	}
+
+	for i, c := range testCases {
+		t.Run(fmt.Sprintf("testcase %d", i),
+			func(t *testing.T) {
+				result, err := p.AppendRecords(context.TODO(), envZone, c.records)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer cleanupRecords(t, p, result)
+
+				if len(result) != len(c.expected) {
+					t.Fatalf("unexpected number of records created: expected %d != actual %d", len(c.expected), len(result))
+				}
+
+				// results are returned in arbitrary order
+				for _, r := range c.expected {
+					if containsRecord(r, result) == nil {
+						t.Fatalf("record %+v was not created", r)
+					}
+				}
+				// each created record must have an ID
+				for _, r := range result {
+					if r.ID == "" {
+						t.Fatalf("no ID set in result %+v", r)
+					}
+				}
+			})
+	}
+}
+
+func Test_DeleteRecords(t *testing.T) {
+	p := &ionos.Provider{AuthAPIToken: envToken}
+
+	// run the test 2 times: first delete with the record ID, second run without
+	for _, clearID := range []bool{true, false} {
+		t.Run(fmt.Sprintf("clear record.ID=%v", clearID),
+			func(t *testing.T) {
+				// create a random TXT record
+				name := randSeq(32)
+				records := []libdns.Record{{Type: "TXT", Name: name, Value: "my record", TTL: ttl}}
+				records, err := p.SetRecords(context.TODO(), envZone, records)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(records) != 1 {
+					t.Fatalf("expected only 1 record to be created, but got %d", len(records))
+				}
+
+				// make sure the record exists in the zone
+				allRecords, err := p.GetRecords(context.TODO(), envZone)
+				if err != nil {
+					t.Fatal(err)
+				}
+				checkExcatlyOneRecordExists(t, allRecords, "TXT", name, "\"my record\"")
+
+				// test with- and without a recordID
+				if clearID {
+					records[0].ID = ""
+				}
+				records, err = p.DeleteRecords(context.TODO(), envZone, records)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(records) != 1 {
+					t.Fatalf("expected only 1 record to be deleted, but got %d", len(records))
+				}
+
+				// make sure the record is no longer in the zone
+				allRecords, err = p.GetRecords(context.TODO(), envZone)
+				if err != nil {
+					t.Fatal(err)
+				}
+				checkNoRecordExists(t, allRecords, name)
+			})
+	}
+}
+
+// Test_GetRecords creates some records and checks using GetRecords that
+// the records are returned as expected
+func Test_GetRecords(t *testing.T) {
+	p := &ionos.Provider{AuthAPIToken: envToken}
+
+	// create some test records
+	prefix := randSeq(32)
+	records := []libdns.Record{
+		{Type: "TXT", Name: prefix + "_test_1", Value: "val_1", TTL: ttl},
+		{Type: "A", Name: prefix + "_test_2", Value: "1.2.3.4", TTL: ttl}}
+	created, err := p.AppendRecords(context.TODO(), envZone, records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(created) != len(records) {
+		t.Fatalf("expected %d records to be created, got %d", len(records), len(created))
+	}
+	defer cleanupRecords(t, p, created)
+
+	// read all records of the zone and check that our records are contained
+	allRecords, err := p.GetRecords(context.TODO(), envZone)
+	if len(allRecords) < len(records) {
+		t.Fatalf("expected to read at least %d records from zone, but got %d", len(records), len(allRecords))
+	}
+
+	for _, r := range created {
+		found := containsRecord(r, allRecords)
+		if found == nil {
+			t.Fatalf("Record %s not found", r.ID)
+		}
+		if found.ID != r.ID {
+			t.Fatalf("Record found but ID differs (%s != %s)", r.ID, found.ID)
+		}
+	}
+}
+
+func Test_UpdateRecords(t *testing.T) {
+	p := &ionos.Provider{AuthAPIToken: envToken}
+
+	// run the test 2 times: first delete with the record ID, second run without
+	for _, clearID := range []bool{true, false} {
+		t.Run(fmt.Sprintf("clear record.ID=%v", clearID),
+			func(t *testing.T) {
+				// create a random A record
+				name := randSeq(32)
+				records := []libdns.Record{{Type: "A", Name: name, Value: "1.2.3.4", TTL: ttl}}
+				records, err := p.SetRecords(context.TODO(), envZone, records)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer cleanupRecords(t, p, slices.Clone(records))
+
+				if len(records) != 1 {
+					t.Fatalf("expected only 1 record to be created, but got %d", len(records))
+				}
+
+				// test with- and without a recordID
+				if clearID {
+					records[0].ID = ""
+				}
+				records[0].Value = "1.2.3.5"
+				records, err = p.SetRecords(context.TODO(), envZone, records)
+				if len(records) != 1 {
+					t.Fatalf("expected only 1 record to be updated, but got %d", len(records))
+				}
+
+				// read all records and check for the expected changes
+				records, err = p.GetRecords(context.TODO(), envZone)
+				if err != nil {
+					t.Fatal(err)
+				}
+				checkExcatlyOneRecordExists(t, records, "A", name, "1.2.3.5")
+			})
 	}
 }
 
@@ -78,202 +293,9 @@ func TestMain(m *testing.M) {
 		fmt.Println(`Please notice that this test runs agains the public ionos DNS Api, so you sould
 never run the test with a zone, used in production.
 To run this test, you have to specify 'LIBDNS_IONOS_TEST_TOKEN' and 'LIBDNS_IONOS_TEST_ZONE'.
-Example: "LIBDNS_IONOS_TEST_TOKEN="123" LIBDNS_IONOS_TEST_ZONE="my-domain.com" go test ./... -v`)
+Example: "LIBDNS_IONOS_TEST_TOKEN="123.456" LIBDNS_IONOS_TEST_ZONE="my-domain.com" go test ./... -v`)
 		os.Exit(1)
 	}
 
 	os.Exit(m.Run())
-}
-
-func Test_AppendRecords(t *testing.T) {
-	p := &ionos.Provider{
-		AuthAPIToken: envToken,
-	}
-
-	testCases := []struct {
-		records  []libdns.Record
-		expected []libdns.Record
-	}{
-		{
-			// multiple records
-			records: []libdns.Record{
-				{Type: "TXT", Name: "test_1", Value: "test_1", TTL: ttl},
-				{Type: "TXT", Name: "test_2", Value: "test_2", TTL: ttl},
-				{Type: "TXT", Name: "test_3", Value: "test_3", TTL: ttl},
-				{Type: "TXT", Name: "test_4", Value: "test_3", TTL: 0},
-			},
-			expected: []libdns.Record{
-				{Type: "TXT", Name: "test_1", Value: "test_1", TTL: ttl},
-				{Type: "TXT", Name: "test_2", Value: "test_2", TTL: ttl},
-				{Type: "TXT", Name: "test_3", Value: "test_3", TTL: ttl},
-				{Type: "TXT", Name: "test_4", Value: "test_3", TTL: 0},
-			},
-		},
-		{
-			// relative name
-			records: []libdns.Record{
-				{Type: "TXT", Name: "123.test", Value: "123", TTL: ttl},
-			},
-			expected: []libdns.Record{
-				{Type: "TXT", Name: "123.test", Value: "123", TTL: ttl},
-			},
-		},
-		{
-			// (fqdn) sans trailing dot
-			records: []libdns.Record{
-				{Type: "TXT", Name: fmt.Sprintf("123.test.%s", strings.TrimSuffix(envZone, ".")), Value: "test", TTL: ttl},
-			},
-			expected: []libdns.Record{
-				{Type: "TXT", Name: "123.test", Value: "test", TTL: ttl},
-			},
-		},
-		{
-			// fqdn with trailing dot
-			records: []libdns.Record{
-				{Type: "TXT", Name: fmt.Sprintf("123.test.%s.", strings.TrimSuffix(envZone, ".")), Value: "test", TTL: ttl},
-			},
-			expected: []libdns.Record{
-				{Type: "TXT", Name: "123.test", Value: "test", TTL: ttl},
-			},
-		},
-	}
-
-	for _, c := range testCases {
-		func() {
-			result, err := p.AppendRecords(context.TODO(), envZone+".", c.records)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer cleanupRecords(t, p, result)
-
-			if len(result) != len(c.records) {
-				t.Fatalf("len(resilt) != len(c.records) => %d != %d", len(c.records), len(result))
-			}
-
-			for k, r := range result {
-				if len(result[k].ID) == 0 {
-					t.Fatalf("len(result[%d].ID) == 0", k)
-				}
-				if r.Type != c.expected[k].Type {
-					t.Fatalf("r.Type != c.exptected[%d].Type => %s != %s", k, r.Type, c.expected[k].Type)
-				}
-				if r.Name != c.expected[k].Name {
-					t.Fatalf("r.Name != c.exptected[%d].Name => %s != %s", k, r.Name, c.expected[k].Name)
-				}
-				if r.Value != c.expected[k].Value {
-					t.Fatalf("r.Value != c.exptected[%d].Value => %s != %s", k, r.Value, c.expected[k].Value)
-				}
-				if r.TTL != c.expected[k].TTL {
-					t.Fatalf("r.TTL != c.exptected[%d].TTL => %s != %s", k, r.TTL, c.expected[k].TTL)
-				}
-			}
-		}()
-	}
-}
-
-func Test_DeleteRecords(t *testing.T) {
-	p := &ionos.Provider{
-		AuthAPIToken: envToken,
-	}
-
-	testRecords, cleanupFunc := setupTestRecords(t, p)
-	defer cleanupFunc()
-
-	records, err := p.GetRecords(context.TODO(), envZone)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(records) < len(testRecords) {
-		t.Fatalf("len(records) < len(testRecords) => %d < %d", len(records), len(testRecords))
-	}
-
-	for _, testRecord := range testRecords {
-		var foundRecord *libdns.Record
-		for _, record := range records {
-			if testRecord.ID == record.ID {
-				foundRecord = &testRecord
-			}
-		}
-
-		if foundRecord == nil {
-			t.Fatalf("Record not found => %s", testRecord.ID)
-		}
-	}
-}
-
-func Test_GetRecords(t *testing.T) {
-	p := &ionos.Provider{
-		AuthAPIToken: envToken,
-	}
-
-	testRecords, cleanupFunc := setupTestRecords(t, p)
-	defer cleanupFunc()
-
-	records, err := p.GetRecords(context.TODO(), envZone)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if len(records) < len(testRecords) {
-		t.Fatalf("len(records) < len(testRecords) => %d < %d", len(records), len(testRecords))
-	}
-
-	for _, testRecord := range testRecords {
-		var foundRecord *libdns.Record
-		for _, record := range records {
-			if testRecord.ID == record.ID {
-				foundRecord = &testRecord
-			}
-		}
-
-		if foundRecord == nil {
-			t.Fatalf("Record not found => %s", testRecord.ID)
-		}
-	}
-}
-
-func Test_SetRecords(t *testing.T) {
-	p := &ionos.Provider{
-		AuthAPIToken: envToken,
-	}
-
-	existingRecords, _ := setupTestRecords(t, p)
-	newTestRecords := []libdns.Record{
-		{
-			Type:  "TXT",
-			Name:  "new_test1",
-			Value: "new_test1",
-			TTL:   ttl,
-		},
-		{
-			Type:  "TXT",
-			Name:  "new_test2",
-			Value: "new_test2",
-			TTL:   ttl,
-		},
-		{
-			Type:  "TXT",
-			Name:  "new_test3",
-			Value: "new_test3",
-			TTL:   0,
-		},
-	}
-
-	allRecords := append(existingRecords, newTestRecords...)
-	allRecords[0].Value = "new_value"
-
-	records, err := p.SetRecords(context.TODO(), envZone, allRecords)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanupRecords(t, p, records)
-
-	if len(records) != len(allRecords) {
-		t.Fatalf("len(records) != len(allRecords) => %d != %d", len(records), len(allRecords))
-	}
-
-	if records[0].Value != "new_value" {
-		t.Fatalf(`records[0].Value != "new_value" => %s != "new_value"`, records[0].Value)
-	}
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -105,30 +105,30 @@ func Test_AppendRecords(t *testing.T) {
 		{
 			// multiple records
 			records: []libdns.Record{
-				{Type: "TXT", Name: prefix + "_test_1", Value: "val_1", TTL: ttl},
-				{Type: "TXT", Name: prefix + "_test_2", Value: "val_2", TTL: 0},
+				{Type: "TXT", Name: prefix + "_atest_1", Value: "val_1", TTL: ttl},
+				{Type: "TXT", Name: prefix + "_atest_2", Value: "val_2", TTL: 0},
 			},
 			expected: []libdns.Record{
-				{Type: "TXT", Name: prefix + "_test_1", Value: "val_1", TTL: ttl},
-				{Type: "TXT", Name: prefix + "_test_2", Value: "val_2", TTL: time.Hour},
+				{Type: "TXT", Name: prefix + "_atest_1", Value: "val_1", TTL: ttl},
+				{Type: "TXT", Name: prefix + "_atest_2", Value: "val_2", TTL: time.Hour},
 			},
 		},
 		{
 			// relative name
 			records: []libdns.Record{
-				{Type: "TXT", Name: prefix + "123.test", Value: "123", TTL: ttl},
+				{Type: "TXT", Name: prefix + "123.atest", Value: "123", TTL: ttl},
 			},
 			expected: []libdns.Record{
-				{Type: "TXT", Name: prefix + "123.test", Value: "123", TTL: ttl},
+				{Type: "TXT", Name: prefix + "123.atest", Value: "123", TTL: ttl},
 			},
 		},
 		{
 			// A records
 			records: []libdns.Record{
-				{Type: "A", Name: prefix + "456.test.", Value: "1.2.3.4", TTL: ttl},
+				{Type: "A", Name: prefix + "456.atest.", Value: "1.2.3.4", TTL: ttl},
 			},
 			expected: []libdns.Record{
-				{Type: "A", Name: prefix + "456.test", Value: "1.2.3.4", TTL: ttl},
+				{Type: "A", Name: prefix + "456.atest", Value: "1.2.3.4", TTL: ttl},
 			},
 		},
 	}
@@ -176,6 +176,7 @@ func Test_DeleteRecords(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
+				//defer cleanupRecords(t, p, slices.Clone(records))
 				if len(records) != 1 {
 					t.Fatalf("expected only 1 record to be created, but got %d", len(records))
 				}
@@ -207,6 +208,24 @@ func Test_DeleteRecords(t *testing.T) {
 				checkNoRecordExists(t, allRecords, name)
 			})
 	}
+}
+
+func Test_DeleteRecordsWillNotDeleteWithoutTypeOrNameWhenNoIDisGiven(t *testing.T) {
+	p := &ionos.Provider{AuthAPIToken: envToken}
+
+	records := []libdns.Record{
+		{ID: "", Type: "TXT", Name: "", Value: "", TTL: ttl},
+		{ID: "", Type: "", Name: "X", Value: "", TTL: ttl},
+		{ID: "", Type: "", Name: "", Value: "", TTL: ttl}}
+
+	records, err := p.DeleteRecords(context.TODO(), envZone, records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("expected no record to be deleted, but got %d", len(records))
+	}
+
 }
 
 // Test_GetRecords creates some records and checks using GetRecords that


### PR DESCRIPTION
Delete and Update may be called without a record ID provided. In this case the record is lookup up by (type, name) and the ID of the found record is then used.

